### PR TITLE
Fixed: Resource Loader does not see all files

### DIFF
--- a/neetbox/integrations/resource.py
+++ b/neetbox/integrations/resource.py
@@ -68,22 +68,22 @@ class ResourceLoader:
         def can_match(path: pathlib.Path):
             if not path.is_file():
                 return False
-            pattern = "**/*." if self._scan_sub_dirs else "*."
             for file_type in self._file_types:
-                if path.match(pattern + file_type):
+                if path.match('*.' + file_type):
                     return True
             return False
 
         def perform_scan():
+            glob_str = '**/*' if self._scan_sub_dirs else "*"
             if not verbose:  # do not output
                 self.file_path_list = [
                     str(path)
-                    for path in pathlib.Path(self.path).glob("**/*")
+                    for path in pathlib.Path(self.path).glob(glob_str)
                     if can_match(path)
                 ]
             else:
                 self.file_path_list = []
-                for path in tqdm(pathlib.Path(self.path).glob("**/*")):
+                for path in tqdm(pathlib.Path(self.path).glob(glob_str)):
                     if can_match(path):
                         self.file_path_list.append(path)
             self._ready = True


### PR DESCRIPTION
- Resource Loader doesn't see files directly under specified path This is due to an unknown feature of built-in pathlib. As is stated in Python docs, `match` accepts glob-like path, but in fact, `match` provided with `**/*` cannot match `foo.bar`, while glob may provide `foo.bar` with the same glob-style pattern. This might be a bug or an simple undocumented behavior or documented somewhere else that I haven't seen yet.