### PR TITLE
[Feature][Daemon] Support daemon on windows

### DIFF
--- a/neetbox/__init__.py
+++ b/neetbox/__init__.py
@@ -8,10 +8,13 @@ from neetbox.utils.framing import get_frame_module_traceback
 module = get_frame_module_traceback(1).__name__
 config_file_name = f"{module}.toml"
 
+
 def post_init():
     import setproctitle
-    project_name = get_module_level_config()['name']
+
+    project_name = get_module_level_config()["name"]
     setproctitle.setproctitle(project_name)
+
 
 def init(path=None, load=False, **kwargs) -> bool:
     if path:

--- a/neetbox/daemon/_win_service.py
+++ b/neetbox/daemon/_win_service.py
@@ -61,6 +61,21 @@ def installService(
     cls._svc_reg_class_ = "%s.%s" % (module_file, cls.__name__)
     if stay_alive:
         win32api.SetConsoleCtrlHandler(lambda x: True, True)
+
+    # check if the service is already installed
+    try:
+        win32serviceutil.QueryServiceStatus(cls._svc_name_)
+        logger.log(f"Service {name} already installed.")
+
+        # if installed, start it
+        win32serviceutil.StartService(cls._svc_name_)
+        logger.log(f"Service {name} started successfully.")
+        return
+    except win32service.error as e:
+        logger.err(f"Service {name} start failed because {e}.")
+        raise
+
+    # install and start the service
     try:
         win32serviceutil.InstallService(
             cls._svc_reg_class_,

--- a/neetbox/daemon/_win_service.py
+++ b/neetbox/daemon/_win_service.py
@@ -1,0 +1,89 @@
+import os
+import sys
+from os.path import splitext, abspath
+from sys import modules
+
+import win32api
+import win32event
+import win32service
+import win32serviceutil
+
+from neetbox.daemon._daemon import daemon_process
+from neetbox.logging import logger
+
+
+class PythonService(win32serviceutil.ServiceFramework):
+    _svc_name_ = "NEETBOX"
+    _svc_description_ = "NEETBOX daemon service"
+    _config = None
+
+    def __init__(self, args):
+        win32serviceutil.ServiceFramework.__init__(self, args)
+        self.hWaitStop = win32event.CreateEvent(None, 0, 0, None)
+        # redirect stdout and stderr to files for logging
+        # the dir of the log files is the dir of the service exe
+        # For the conda env, the dir will be like:
+        # D:\Softwares\Miniconda3\envs\xxx\Lib\site-packages\win32
+        sys.stdout = open(os.path.join(os.getcwd(), "stdout.log"), "a+")
+        sys.stderr = open(os.path.join(os.getcwd(), "stderr.log"), "a+")
+        self.run = True
+
+    @staticmethod
+    def set_config(config):
+        PythonService._config = config
+
+    def SvcDoRun(self):
+        try:
+            daemon_process(self._config)
+        except Exception as e:
+            logger.err(f"Service {self._svc_name_} failed because {e}.")
+            self.SvcStop()
+
+    def SvcStop(self):
+        self.ReportServiceStatus(win32service.SERVICE_STOP_PENDING)
+        win32event.SetEvent(self.hWaitStop)
+        self.run = False
+
+
+def installService(
+    cls=PythonService, cfg=None, display_name: str = None, stay_alive: bool = True
+):
+    cls.set_config(cfg)
+    name = cls._svc_name_
+    cls._svc_display_name_ = display_name or name
+    try:
+        module_path = modules[cls.__module__].__file__
+    except AttributeError:
+        from sys import executable
+
+        module_path = executable
+    module_file = splitext(abspath(module_path))[0]
+    cls._svc_reg_class_ = "%s.%s" % (module_file, cls.__name__)
+    if stay_alive:
+        win32api.SetConsoleCtrlHandler(lambda x: True, True)
+    try:
+        win32serviceutil.InstallService(
+            cls._svc_reg_class_,
+            cls._svc_name_,
+            cls._svc_display_name_,
+            startType=win32service.SERVICE_AUTO_START,
+        )
+        logger.log(f"Service {name} installed successfully.")
+        win32serviceutil.StartService(cls._svc_name_)
+        logger.log(f"Service {name} started successfully.")
+    except Exception as e:
+        logger.err(f"Service {name} install failed because {e}.")
+        raise
+
+
+if __name__ == "__main__":
+    # just for test
+    PythonService.set_config(
+        {
+            "server": "localhost",
+            "port": 20202,
+            "enable": True,
+        }
+    )
+    # win32serviceutil.HandleCommandLine(PythonService)
+    installService()

--- a/neetbox/daemon/_win_service.py
+++ b/neetbox/daemon/_win_service.py
@@ -12,7 +12,7 @@ from neetbox.daemon._daemon import daemon_process
 from neetbox.logging import logger
 
 
-class PythonService(win32serviceutil.ServiceFramework):
+class NEETBOXService(win32serviceutil.ServiceFramework):
     _svc_name_ = "NEETBOX"
     _svc_description_ = "NEETBOX daemon service"
     _config = None
@@ -30,7 +30,7 @@ class PythonService(win32serviceutil.ServiceFramework):
 
     @staticmethod
     def set_config(config):
-        PythonService._config = config
+        NEETBOXService._config = config
 
     def SvcDoRun(self):
         try:
@@ -46,7 +46,7 @@ class PythonService(win32serviceutil.ServiceFramework):
 
 
 def installService(
-    cls=PythonService, cfg=None, display_name: str = None, stay_alive: bool = True
+    cls=NEETBOXService, cfg=None, display_name: str = None, stay_alive: bool = True
 ):
     cls.set_config(cfg)
     name = cls._svc_name_
@@ -93,12 +93,12 @@ def installService(
 
 if __name__ == "__main__":
     # just for test
-    PythonService.set_config(
+    NEETBOXService.set_config(
         {
             "server": "localhost",
             "port": 20202,
             "enable": True,
         }
     )
-    # win32serviceutil.HandleCommandLine(PythonService)
+    # win32serviceutil.HandleCommandLine(NEETBOXService)
     installService()


### PR DESCRIPTION
## Type
Feature

## Description
In this PR, I implemented the daemon functionality on Windows as requested in issue #32.

## Implementation
Since `os.fork()` and the `python-daemon` library cannot be used on Windows, I used the `win32service` and `win32serviceutil` modules to achieve similar functionality.

We registered a service named NEETBOX on Windows and installed and started it in `daemon/__init__.py`.

## Notes

> ⚠ Because installing the service requires Windows administrator privileges, please test it with administrator privileges.

@visualDust cc. @therainisme 