### PR TITLE
Privilege-free & cross-platform daemon

### DIFF
--- a/neetbox/__init__.py
+++ b/neetbox/__init__.py
@@ -70,6 +70,8 @@ def init(path=None, load=False, **kwargs) -> bool:
         logger.err(f"Failed to load config from {config_file_path}: {e}")
         return False
 
-
-if os.path.isfile(config_file_name):  # if in a workspace
+is_in_daemon_process = 'NEETBOX_DAEMON_PROCESS' in os.environ and os.environ['NEETBOX_DAEMON_PROCESS'] == '1'
+print('prevent_daemon_loading =', is_in_daemon_process)
+if os.path.isfile(config_file_name) and not is_in_daemon_process:  # if in a workspace
     init(load=True)
+

--- a/neetbox/daemon/__init__.py
+++ b/neetbox/daemon/__init__.py
@@ -45,12 +45,13 @@ def __attach_daemon(daemon_config):
         time.sleep(1)
         _retry = 3
         while not connect_daemon(daemon_config):  # try connect daemon
-            logger.warn(f"Could not connect to the daemon. {_retry} retries remaining.")
+            logger.warn(
+                f"Could not connect to the daemon. {_retry} retries remaining.")
             time.sleep(1)
             _retry -= 1
             if not _retry:
                 logger.err(
-                    "Connect daemon faild after 3 retries, daemon connector won't start."
+                    "Failed to connect to daemon after 3 retries, daemon connector won't start."
                 )
                 return False
         return True

--- a/neetbox/daemon/__init__.py
+++ b/neetbox/daemon/__init__.py
@@ -33,6 +33,15 @@ def __attach_daemon(daemon_config):
         logger.log(
             f"No daemon running at {daemon_config['server']}:{daemon_config['port']}, trying to create daemon..."
         )
+
+        popen = DaemonableProcess(
+            target='neetbox.daemon._daemon_launcher',
+            args=['--config', json.dumps(daemon_config)],
+            mode='detached',
+            redirect_stdout=None,
+            env_append={'NEETBOX_DAEMON_PROCESS': '1'},
+        ).start()
+
         time.sleep(1)
         _retry = 3
         while not connect_daemon(daemon_config):  # try connect daemon

--- a/neetbox/daemon/__init__.py
+++ b/neetbox/daemon/__init__.py
@@ -5,11 +5,14 @@
 # Date:   20230414
 
 from neetbox.daemon._daemon_client import connect_daemon
+from neetbox.daemon.daemonable_process import DaemonableProcess
 from neetbox.logging import logger
 from neetbox.utils import pkg
+from neetbox.pipeline import watch, listen
 import platform
 import time
 import os
+import json
 
 
 def __attach_daemon(daemon_config):
@@ -25,38 +28,11 @@ def __attach_daemon(daemon_config):
             )
             return False  # ignore if debugging in ipython
     _online_status = connect_daemon(daemon_config)  # try to connect daemon
+    logger.log('daemon connection status: ' + str(_online_status))
     if not _online_status:  # if no daemon online
         logger.log(
             f"No daemon running at {daemon_config['server']}:{daemon_config['port']}, trying to create daemon..."
         )
-        if platform.system() == "Windows":  # running on windows
-            try:
-                assert pkg.is_installed(
-                    "win32api", try_install_if_not="pywin32"
-                ), "Please install 'pywin32' before using NEETBOX daemon"
-                assert pkg.is_installed(
-                    "win32serviceutil", try_install_if_not="pypiwin32"
-                ), "Please install 'pywin32' before using NEETBOX daemon"
-                from neetbox.daemon._win_service import installService
-
-                installService(cfg=daemon_config)
-            except Exception as e:
-                logger.err(f"Could not install Windows service because {e}.")
-                return False
-        else:  # not on windows
-            pid = os.fork()
-            if pid == 0:  # child process
-                pkg.is_installed("daemon", try_install_if_not="python-daemon")
-                import daemon
-                from neetbox.daemon._daemon import daemon_process
-
-                with daemon.DaemonContext():
-                    daemon_process(daemon_config)  # create daemon
-            elif pid < 0:
-                logger.err(
-                    "Faild to spawn daemon process using os.fork. NEETBOX daemon will not start."
-                )
-                return False
         time.sleep(1)
         _retry = 3
         while not connect_daemon(daemon_config):  # try connect daemon

--- a/neetbox/daemon/_apis.py
+++ b/neetbox/daemon/_apis.py
@@ -7,9 +7,10 @@
 
 from neetbox.utils import pkg
 from neetbox.utils.framing import get_frame_module_traceback
+from neetbox.daemon._local_http_client import _local_http_client
 module_name = get_frame_module_traceback().__name__
-assert pkg.is_installed('requests', try_install_if_not=True), f"{module_name} requires requests which is not installed"
-import requests
+assert pkg.is_installed('httpx', try_install_if_not=True), f"{module_name} requires httpx which is not installed"
+import httpx
 from neetbox.config import get_module_level_config
 from neetbox.logging import logger
 import time
@@ -24,6 +25,6 @@ def get_status_of(name=None):
     name = name or ""
     api_addr = f"{base_addr}/status"
     logger.info(f"Fetching from {api_addr}")
-    r = requests.get(api_addr)
+    r = _local_http_client.get(api_addr)
     _data = r.json()
     return _data

--- a/neetbox/daemon/_daemon_client.py
+++ b/neetbox/daemon/_daemon_client.py
@@ -23,6 +23,8 @@ assert pkg.is_installed(
 
 __TIME_UNIT_SEC = 0.1
 
+__upload_thread: Thread = None
+
 
 def _upload_thread(daemon_config, base_addr, display_name):
     _ctr = 0
@@ -98,10 +100,12 @@ def connect_daemon(daemon_config):
         logger.err(e)
         return False
 
-    upload_thread = Thread(target=_upload_thread,
-                           daemon=True,
-                           args=[daemon_config, base_addr, _display_name]
-                           )
-    upload_thread.start()
+    global __upload_thread
+    if __upload_thread is None or not __upload_thread.is_alive():
+        __upload_thread = Thread(target=_upload_thread,
+                                daemon=True,
+                                args=[daemon_config, base_addr, _display_name]
+                                )
+        __upload_thread.start()
 
     return True

--- a/neetbox/daemon/_daemon_client.py
+++ b/neetbox/daemon/_daemon_client.py
@@ -27,20 +27,29 @@ def connect_daemon(daemon_config):
     _display_name = _display_name or _launch_config["name"]
 
     logger.log(
-        f"Connecting daemon at {daemon_config['server']}:{daemon_config['port']} ..."
+        f"Connecting to daemon at {daemon_config['server']}:{daemon_config['port']} ..."
     )
     _daemon_address = f"{daemon_config['server']}:{daemon_config['port']}"
     base_addr = f"http://{_daemon_address}"
 
     # check if daemon is alive
     def _check_daemon_alive():
+        no_proxy = {
+            "http": None, 
+            "https": None
+        }
+
         _api_name = "hello"
         _api_addr = f"{base_addr}/{_api_name}"
-        r = requests.get(_api_addr)
+        r = requests.get(_api_addr, proxies=no_proxy)
+        if not r.ok:
+            raise IOError(f"Daemon at {_api_addr} is not alive. ({r.status_code}")
+        logger.log(f'daemon response from {_api_addr} is {r} ({r.status_code})')
 
     try:
         _check_daemon_alive()
     except Exception as e:
+        logger.err(e)
         return False
 
     def _upload_thread():

--- a/neetbox/daemon/_daemon_client.py
+++ b/neetbox/daemon/_daemon_client.py
@@ -4,22 +4,71 @@
 # URL:    https://gong.host
 # Date:   20230414
 
+from neetbox.pipeline._signal_and_slot import _update_value_dict
+from neetbox.logging import logger
+from neetbox.config import get_module_level_config
+from threading import Thread
+import json
+import time
+import httpx
 from neetbox.utils import pkg
 from neetbox.utils.framing import get_frame_module_traceback
 
+from neetbox.daemon._local_http_client import _local_http_client
+
 module_name = get_frame_module_traceback().__name__
 assert pkg.is_installed(
-    "requests", try_install_if_not=True
-), f"{module_name} requires requests which is not installed"
-import requests
-import time
-import json
-from threading import Thread
-from neetbox.config import get_module_level_config
-from neetbox.logging import logger
-from neetbox.pipeline._signal_and_slot import _update_value_dict
+    "httpx", try_install_if_not=True
+), f"{module_name} requires httpx which is not installed"
 
 __TIME_UNIT_SEC = 0.1
+
+
+def _upload_thread(daemon_config, base_addr, display_name):
+    _ctr = 0
+    _api_name = "sync"
+    _api_addr = f"{base_addr}/{_api_name}/{display_name}"
+    global _update_value_dict
+    _disconnect_flag = False
+    _disconnect_retries = 10
+    while True:
+        _ctr = (_ctr + 1) % 99999999
+        _upload_interval = daemon_config["uploadInterval"]
+        time.sleep(__TIME_UNIT_SEC)
+        if _ctr % _upload_interval:  # not zero
+            continue
+        # upload data
+        _data = json.dumps(_update_value_dict, default=str)
+        _headers = {"Content-Type": "application/json"}
+        try:
+            resp = _local_http_client.post(
+                _api_addr, data=_data, headers=_headers)
+            if resp.is_error:
+                raise IOError(
+                    f"Failed to upload data to daemon. ({resp.status_code})")
+        except Exception as e:
+            if _disconnect_flag:
+                _disconnect_retries -= 1
+                if not _disconnect_retries:
+                    logger.err(
+                        "Failed to reconnect to daemon after {10} retries, Trying to launch new daemon..."
+                    )
+                    from neetbox.daemon import _try_attach_daemon
+
+                    _try_attach_daemon()
+                    time.sleep(__TIME_UNIT_SEC)
+                continue
+            logger.warn(
+                f"Failed to upload data to daemon cause {e}. Waiting for reconnect..."
+            )
+            _disconnect_flag = True
+        else:
+            if not _disconnect_flag:
+                continue
+            logger.ok(f"Successfully reconnected to daemon.")
+            _disconnect_flag = False
+            _disconnect_retries = 10
+
 
 def connect_daemon(daemon_config):
     _display_name = get_module_level_config()["displayName"]
@@ -34,17 +83,14 @@ def connect_daemon(daemon_config):
 
     # check if daemon is alive
     def _check_daemon_alive():
-        no_proxy = {
-            "http": None, 
-            "https": None
-        }
-
         _api_name = "hello"
         _api_addr = f"{base_addr}/{_api_name}"
-        r = requests.get(_api_addr, proxies=no_proxy)
-        if not r.ok:
-            raise IOError(f"Daemon at {_api_addr} is not alive. ({r.status_code}")
-        logger.log(f'daemon response from {_api_addr} is {r} ({r.status_code})')
+        r = _local_http_client.get(_api_addr)
+        if r.is_error:
+            raise IOError(
+                f"Daemon at {_api_addr} is not alive. ({r.status_code})")
+        logger.log(
+            f'daemon response from {_api_addr} is {r} ({r.status_code})')
 
     try:
         _check_daemon_alive()
@@ -52,48 +98,10 @@ def connect_daemon(daemon_config):
         logger.err(e)
         return False
 
-    def _upload_thread():
-        _ctr = 0
-        _api_name = "sync"
-        _api_addr = f"{base_addr}/{_api_name}/{_display_name}"
-        global _update_value_dict
-        _disconnect_flag = False
-        _disconnect_retries = 10
-        while True:
-            _ctr = (_ctr + 1) % 99999999
-            _upload_interval = daemon_config["uploadInterval"]
-            time.sleep(__TIME_UNIT_SEC)
-            if _ctr % _upload_interval:  # not zero
-                continue
-            # upload data
-            _data = json.dumps(_update_value_dict, default=str)
-            _headers = {"Content-Type": "application/json"}
-            try:
-                requests.post(_api_addr, data=_data, headers=_headers)
-            except Exception as e:
-                if _disconnect_flag:
-                    _disconnect_retries -= 1
-                    if not _disconnect_retries:
-                        logger.err(
-                            "Failed to reconnect to daemon after {10} retries, Trying to launch new daemon..."
-                        )
-                        from neetbox.daemon import _try_attach_daemon
-
-                        _try_attach_daemon()
-                        time.sleep(__TIME_UNIT_SEC)
-                    continue
-                logger.warn(
-                    f"Failed to upload data to daemon cause {e}. Waiting for reconnect..."
-                )
-                _disconnect_flag = True
-            else:
-                if not _disconnect_flag:
-                    continue
-                logger.ok(f"Succefully reconnected to daemon.")
-                _disconnect_flag = False
-                _disconnect_retries = 10
-
-    upload_thread = Thread(target=_upload_thread, daemon=True)
+    upload_thread = Thread(target=_upload_thread,
+                           daemon=True,
+                           args=[daemon_config, base_addr, _display_name]
+                           )
     upload_thread.start()
 
     return True

--- a/neetbox/daemon/_daemon_launcher.py
+++ b/neetbox/daemon/_daemon_launcher.py
@@ -9,6 +9,7 @@ import json
 import argparse
 
 from neetbox.daemon._daemon import daemon_process
+# from neetbox.daemon._local_http_client import _local_http_client
 
 def run():
     if len(sys.argv) <= 1:

--- a/neetbox/daemon/_daemon_launcher.py
+++ b/neetbox/daemon/_daemon_launcher.py
@@ -1,0 +1,33 @@
+print('========= If you see this on Windows, your subprocess is running with consoles merged =========')
+print('========= This happens when your DaemonableProcess runs in attached mode. =========')
+
+import os
+import sys
+
+# sys.stdout=open(r'D:\Projects\ML\neetbox\logdir\daemon.log', 'a+')
+
+import json
+import argparse
+print('imported external packages')
+
+from neetbox.daemon._daemon import daemon_process
+print('imported neetbox.daemon')
+
+def run():
+    if len(sys.argv) <= 1:
+        print('_daemon_launcher: Warning: empty daemon_config')
+        daemon_config = {}
+    else:
+        ap = argparse.ArgumentParser()
+        ap.add_argument('--config')
+        args = ap.parse_args()
+        daemon_config = json.loads(args.config)
+        print('Daemon launcher started with config:', daemon_config)
+    daemon_process(daemon_config)
+        
+
+print('_daemon_launcher is starting with __name__ =',
+      __name__, ' and args =', sys.argv)
+
+run()
+print('_daemon_launcher: exiting')

--- a/neetbox/daemon/_daemon_launcher.py
+++ b/neetbox/daemon/_daemon_launcher.py
@@ -1,5 +1,4 @@
-print('========= If you see this on Windows, your subprocess is running with consoles merged =========')
-print('========= This happens when your DaemonableProcess runs in attached mode. =========')
+print('========= Daemon Launcher =========')
 
 import os
 import sys
@@ -8,10 +7,8 @@ import sys
 
 import json
 import argparse
-print('imported external packages')
 
 from neetbox.daemon._daemon import daemon_process
-print('imported neetbox.daemon')
 
 def run():
     if len(sys.argv) <= 1:

--- a/neetbox/daemon/_local_http_client.py
+++ b/neetbox/daemon/_local_http_client.py
@@ -1,0 +1,14 @@
+import httpx
+
+__no_proxy = {
+    "http://": None,
+    "https://": None,
+}
+
+
+def __load_http_client():
+    __local_http_client = httpx.Client(proxies=__no_proxy)
+    return __local_http_client
+
+
+_local_http_client: httpx.Client = __load_http_client()

--- a/neetbox/daemon/daemonable_process.py
+++ b/neetbox/daemon/daemonable_process.py
@@ -1,0 +1,109 @@
+import time
+import subprocess
+import multiprocessing
+
+import os
+import sys
+
+from typing import *
+
+is_ms_windows = 'win32' in sys.platform or 'cygwin' in sys.platform
+
+
+class DaemonableProcess:
+
+    def __init__(
+        self,
+        *,
+        target: str,
+        args: List = [],
+        mode: Literal['attached', 'detached'],
+        redirect_stdout=None,
+        redirect_stderr=subprocess.STDOUT,
+        use_os_spawn_for_daemon=False,
+        redirect_stdin=subprocess.DEVNULL,
+        env_append=None,
+    ):
+        self.target = target
+        self.__args = args
+        self.__mode = mode
+        self.__use_os_spawn_for_daemon = use_os_spawn_for_daemon
+        self.__stdin = redirect_stdin
+        # self.__is_daemon = is_daemon
+        # self.__is_detached = is_detached
+        self.__redirect_stdout=redirect_stdout
+        self.__redirect_stderr=redirect_stderr
+        self.__env = dict(os.environ)
+        if env_append is not None:
+            self.__env.update(env_append)
+        # self.__no_new_window = no_new_window
+
+    @property
+    def is_daemon(self):
+        return self.__mode == 'daemon'
+
+    @property
+    def mode(self):
+        return self.__mode
+
+    # @property
+    # def is_detached(self):
+    #     return self.__is_detached
+
+    def start(self):
+        if self.__use_os_spawn_for_daemon:
+            raise NotImplementedError()
+        else:
+            # use subprocess
+            command_line = [sys.executable, '-m', self.target, *self.__args]
+
+            if is_ms_windows:
+                # windows + subprocess
+                creationflags = {
+                    'attached': 0,
+                    'shared': 0,
+                    'detached': subprocess.CREATE_NO_WINDOW,
+                }[self.__mode]
+
+                popen = subprocess.Popen(
+                    command_line,
+                    creationflags=creationflags,
+                    stdout=self.__redirect_stdout,
+                    stderr=self.__redirect_stderr,
+                    stdin=self.__stdin,
+                    env=self.__env
+                )
+                print(popen)
+
+                # return_code = popen.wait()
+                # print('return_code', return_code)
+            else:
+                # posix + subprocess
+                popen = subprocess.Popen(
+                    command_line,
+                    stdin=self.__stdin,
+                    stdout=self.__redirect_stdout,
+                    stderr=self.__redirect_stderr,
+                    env=self.__env
+                )
+
+                if self.mode == 'attached':
+                    import atexit
+                    atexit.register(lambda: popen.terminate())
+
+                print(popen)
+
+    def terminate(self):
+        pass
+
+
+def main():
+    DaemonableProcess(
+        target='ppcdaemontest.daemon_worker',
+        args=['1'],
+        mode='attached',
+    ).start()
+    time.sleep(3)
+
+if __name__ == '__main__':
+    main()

--- a/neetbox/daemon/daemonable_process.py
+++ b/neetbox/daemon/daemonable_process.py
@@ -84,7 +84,8 @@ class DaemonableProcess:
                     stdin=self.__stdin,
                     stdout=self.__redirect_stdout,
                     stderr=self.__redirect_stderr,
-                    env=self.__env
+                    env=self.__env,
+                    start_new_session=self.mode == 'detached',
                 )
 
                 if self.mode == 'attached':
@@ -92,6 +93,8 @@ class DaemonableProcess:
                     atexit.register(lambda: popen.terminate())
 
                 print(popen)
+            
+            return popen
 
     def terminate(self):
         pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ rich = "^13.3.4"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^6.0.0"
-requests = "^2.28.2"
+httpx = "^0.24.0"
 flask = "^2.2.3"
 
 


### PR DESCRIPTION
This PR contains implementation to create a daemon process that requires no special privileges to maintain running in the background after parent process exits, both on Windows and POSIX operating systems, primarily with `subprocess` module. 

This implementation of daemon process manager supports two modes:
- Detached mode: The child process does not exit when parent exits. (This mode is currently used for NEETBOX daemon)
- Attached mode: The child process exits along with the exit of the parent. 

This implementation has the following requirements and limitations:

On Daemon Process Manager: 
- The executable that launched the parent process must be reentrantly callable, with an accessible executable path and executable permissions. 
- On POSIX, child processes created in "attached" mode may not exit as expected if parent is terminated forcibly (probably, for example, SIGKILL) because this behavior is achieved with `atexit` registerer. 
- The behavior of to where stdout and stderr are redirected in detached mode differs on Windows and POSIX (but you can always mute stdout and stderr). 
- Redirecting output of child process to files hasn't been intentionally checked and tested. 

On the interoperation with neetbox:
- The operating system must support the passing of, change to and access to environment variables. 
- Length of daemon config is limited on that it, when encoded as json, combined with other CLI args, should not exceed the maximum length supported by the operating system. Should this length be exceeded in the future, we can move to temporary files or other techniques instead. 

If this implementation of daemon process manager is to be used in creation of other daemon processes apart from that included in this PR, the following **additional** requirements have to be met:
- The code to run as a daemon process must have a package name that is callable in the form `{path_to_python_executable} -m package.name` (though this can be changed when necessary). 

Tested on Windows 11 and WSL2 Ubuntu 20.04

This PR also introduces some other changes and improvements. See commit history for details. 
